### PR TITLE
Fix includes for cxml.h

### DIFF
--- a/src/cxml.h
+++ b/src/cxml.h
@@ -24,7 +24,8 @@
 #include <boost/optional.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string/erase.hpp>
-#include <stdint.h>
+#include <exception>
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
stdint.h is unnecessary, but std::exception should come from <exception>,
and std::shared_ptr comes from <memory>.

I was having problems building (on NixOS unstable) because apparently std::shared_ptr is no longer included as a side-effect of one of the other headers there. Using include-what-you-use suggested a couple of changes to cxml.h, applied here.